### PR TITLE
Fix behavior when massive data is transmitted

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,5 @@
+export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.3/mod.ts";
+export { deferred } from "https://deno.land/x/std@0.92.0/async/deferred.ts";
+export type {
+  Deferred,
+} from "https://deno.land/x/std@0.92.0/async/deferred.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,0 +1,2 @@
+export { assertEquals } from "https://deno.land/std@0.92.0/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.92.0/async/mod.ts";

--- a/message_test.ts
+++ b/message_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.86.0/testing/asserts.ts";
+import { assertEquals } from "./deps_test.ts";
 import * as message from "./message.ts";
 
 const isRequestMessageTestCases = [

--- a/session.ts
+++ b/session.ts
@@ -1,8 +1,4 @@
-import { decodeStream, encode } from "https://deno.land/x/msgpack@v1.2/mod.ts";
-import {
-  Deferred,
-  deferred,
-} from "https://deno.land/x/std@0.86.0/async/deferred.ts";
+import { decodeStream, Deferred, deferred, encode } from "./deps.ts";
 import * as message from "./message.ts";
 
 const MSGID_THRESHOLD = 2 ** 32;

--- a/session.ts
+++ b/session.ts
@@ -61,13 +61,7 @@ export class Session {
   }
 
   private async send(data: Uint8Array): Promise<void> {
-    while (true) {
-      const n = await this.#writer.write(data);
-      if (n === data.byteLength) {
-        break;
-      }
-      data = data.slice(n);
-    }
+    await Deno.writeAll(this.#writer, data);
   }
 
   private async dispatch(
@@ -97,7 +91,7 @@ export class Session {
       return [result, error];
     })();
     const response: message.ResponseMessage = [1, msgid, error, result];
-    await this.#writer.write(encode(response));
+    await Deno.writeAll(this.#writer, encode(response));
   }
 
   private async handleNotification(

--- a/session_test.ts
+++ b/session_test.ts
@@ -1,5 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.86.0/testing/asserts.ts";
-import { delay } from "https://deno.land/std/async/mod.ts";
+import { assertEquals, delay } from "./deps_test.ts";
 import { Session } from "./session.ts";
 
 class Reader implements Deno.Reader, Deno.Closer {


### PR DESCRIPTION
Run test like

```
deno test --filter massive
```

Then we get

```
failures:

Local can receive Remote massive data
AssertionError: Values are not equal:


    [Diff] Actual / Expected


-   "61, 5462, 5463, ... 1, 7722, 7723, 7724, 7725, 7726, 7727, 7728, 7729, 7730, 7
7"
+   "0000, 0001, 0002, 0003, 0004,...  9991, 9992, 9993, 9994, 9995, 9996, 9997, 9998, 9999, "

    at assertEquals (https://deno.land/std@0.86.0/testing/asserts.ts:214:9)
    at file:///Users/alisue/ghq/github.com/lambdalisue/msgpack-rpc-deno/session_test.ts:194:3
    at async asyncOpSanitizer (deno:runtime/js/40_testing.js:37:9)
    at async resourceSanitizer (deno:runtime/js/40_testing.js:73:7)
    at async Object.exitSanitizer [as fn] (deno:runtime/js/40_testing.js:100:9)
    at async TestRunner.[Symbol.asyncIterator] (deno:runtime/js/40_testing.js:272:13)
    at async Object.runTests (deno:runtime/js/40_testing.js:347:22)
    at async file:///Users/alisue/ghq/github.com/lambdalisue/msgpack-rpc-deno/$deno$test.ts:4:1

failures:

        Local can receive Remote massive data

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 23 filtered out (629ms)
```