### PR TITLE
Fix for Deno v1.9

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,6 @@
 export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.3/mod.ts";
-export { deferred } from "https://deno.land/x/std@0.92.0/async/deferred.ts";
+export { deferred } from "https://deno.land/x/std@0.93.0/async/deferred.ts";
+export * as io from "https://deno.land/x/std@0.93.0/io/mod.ts";
 export type {
   Deferred,
-} from "https://deno.land/x/std@0.92.0/async/deferred.ts";
+} from "https://deno.land/x/std@0.93.0/async/deferred.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.3/mod.ts";
+export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.4/mod.ts";
 export { deferred } from "https://deno.land/x/std@0.93.0/async/deferred.ts";
 export * as io from "https://deno.land/x/std@0.93.0/io/mod.ts";
 export type {

--- a/session.ts
+++ b/session.ts
@@ -1,4 +1,4 @@
-import { decodeStream, Deferred, deferred, encode } from "./deps.ts";
+import { decodeStream, Deferred, deferred, encode, io } from "./deps.ts";
 import * as message from "./message.ts";
 
 const MSGID_THRESHOLD = 2 ** 32;
@@ -57,7 +57,7 @@ export class Session {
   }
 
   private async send(data: Uint8Array): Promise<void> {
-    await Deno.writeAll(this.#writer, data);
+    await io.writeAll(this.#writer, data);
   }
 
   private async dispatch(
@@ -87,7 +87,7 @@ export class Session {
       return [result, error];
     })();
     const response: message.ResponseMessage = [1, msgid, error, result];
-    await Deno.writeAll(this.#writer, encode(response));
+    await io.writeAll(this.#writer, encode(response));
   }
 
   private async handleNotification(
@@ -106,7 +106,7 @@ export class Session {
    * This method must be called to start session.
    */
   async listen(): Promise<void> {
-    const stream = Deno.iter(this.#reader);
+    const stream = io.iter(this.#reader);
     try {
       for await (const data of decodeStream(stream)) {
         if (message.isRequestMessage(data)) {

--- a/session_test.ts
+++ b/session_test.ts
@@ -1,3 +1,4 @@
+import { io } from "./deps.ts";
 import { assertEquals, delay } from "./deps_test.ts";
 import { Session } from "./session.ts";
 
@@ -66,9 +67,9 @@ Deno.test("Make sure that Reader/Writer for tests works properly", async () => {
   const r = new Reader(q);
   const w = new Writer(q);
   const d = (new TextEncoder()).encode(buildMassiveData());
-  await Deno.writeAll(w, d);
+  await io.writeAll(w, d);
   r.close();
-  assertEquals(await Deno.readAll(r), d);
+  assertEquals(await io.readAll(r), d);
 });
 
 Deno.test("Local can call Remote method", async () => {


### PR DESCRIPTION
- [x] Use `io` module instead while Deno.xxxxx are deprecated (https://deno.com/blog/v1.9#new-api-deprecations)
- [x] Update [msgpack-deno](https://github.com/Srinivasa314/msgpack-deno) to fix TS2729 error (waiting for a new release which include https://github.com/Srinivasa314/msgpack-deno/pull/3)