### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export { decodeStream, encode } from "https://deno.land/x/msgpack@v1.4/mod.ts";
-export { deferred, delay } from "https://deno.land/x/std@0.110.0/async/mod.ts";
-export * as io from "https://deno.land/x/std@0.110.0/io/mod.ts";
-export type { Deferred } from "https://deno.land/x/std@0.110.0/async/mod.ts";
+export { deferred, delay } from "https://deno.land/x/std@0.164.0/async/mod.ts";
+export * as io from "https://deno.land/x/std@0.164.0/io/mod.ts";
+export type { Deferred } from "https://deno.land/x/std@0.164.0/async/mod.ts";
 export type { Disposable } from "https://deno.land/x/disposable@v1.0.2/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,3 +1,3 @@
-export * from "https://deno.land/std@0.110.0/testing/asserts.ts";
-export { delay } from "https://deno.land/std@0.110.0/async/mod.ts";
+export * from "https://deno.land/std@0.164.0/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.164.0/async/mod.ts";
 export { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts";


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/indexer_test.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/response_waiter.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/indexer.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/response_waiter_test.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/README.md

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/deps.ts
[1/5] Looking for releases: https://deno.land/x/msgpack@v1.4/mod.ts
[1/5] Skip updating: https://deno.land/x/msgpack@v1.4/mod.ts
[2/5] Looking for releases: https://deno.land/x/std@0.110.0/async/mod.ts
[2/5] Attempting update: https://deno.land/x/std@0.110.0/async/mod.ts -> 0.164.0
[2/5] Update successful: https://deno.land/x/std@0.110.0/async/mod.ts -> 0.164.0
[3/5] Looking for releases: https://deno.land/x/std@0.110.0/io/mod.ts
[3/5] Attempting update: https://deno.land/x/std@0.110.0/io/mod.ts -> 0.164.0
[3/5] Update successful: https://deno.land/x/std@0.110.0/io/mod.ts -> 0.164.0
[4/5] Looking for releases: https://deno.land/x/std@0.110.0/async/mod.ts
[4/5] Attempting update: https://deno.land/x/std@0.110.0/async/mod.ts -> 0.164.0
[4/5] Update successful: https://deno.land/x/std@0.110.0/async/mod.ts -> 0.164.0
[5/5] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts
[5/5] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/mod.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/session_test.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/example/client.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/example/README.md

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/example/server.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/deps_test.ts
[1/3] Looking for releases: https://deno.land/std@0.110.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.110.0/testing/asserts.ts -> 0.164.0
[1/3] Update successful: https://deno.land/std@0.110.0/testing/asserts.ts -> 0.164.0
[2/3] Looking for releases: https://deno.land/std@0.110.0/async/mod.ts
[2/3] Attempting update: https://deno.land/std@0.110.0/async/mod.ts -> 0.164.0
[2/3] Update successful: https://deno.land/std@0.110.0/async/mod.ts -> 0.164.0
[3/3] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts
[3/3] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/message_test.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/message.ts

/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc/session.ts

Already latest version:
https://deno.land/x/msgpack@v1.4/mod.ts == v1.4
https://deno.land/x/disposable@v1.0.2/mod.ts == v1.0.2
https://deno.land/x/disposable@v1.0.2/mod.ts == v1.0.2

Successfully updated:
https://deno.land/x/std@0.110.0/async/mod.ts 0.110.0 -> 0.164.0
https://deno.land/x/std@0.110.0/io/mod.ts 0.110.0 -> 0.164.0
https://deno.land/x/std@0.110.0/async/mod.ts 0.110.0 -> 0.164.0
https://deno.land/std@0.110.0/testing/asserts.ts 0.110.0 -> 0.164.0
https://deno.land/std@0.110.0/async/mod.ts 0.110.0 -> 0.164.0
make[1]: Entering directory '/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc'
make[1]: Leaving directory '/home/runner/work/deno-msgpack-rpc/deno-msgpack-rpc'

```