### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/msgpack_rpc/mod.ts)
 [![Test](https://github.com/lambdalisue/deno-msgpack-rpc/workflows/Test/badge.svg)](https://github.com/lambdalisue/deno-msgpack-rpc/actions?query=workflow%3ATest)
 
+> [!WARNING]
+>
+> This module is for deprecated `Deno.Reader`, `Deno.Writer`, and `Deno.Closer`.
+> Use [deno-messagepack-rpc](https://github.com/lambdalisue/deno-messagepack-rpc) instead for Web standard Streams APIs.
+
 [Deno][deno] module to support [msgpack-rpc][msgpack-rpc] by using
 [msgpack-deno][msgpack-deno].
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README to recommend using `deno-messagepack-rpc` for Web standard Streams APIs instead of `Deno.Reader`, `Deno.Writer`, and `Deno.Closer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->